### PR TITLE
Allow env var for DeepSeek key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ python pipeline.py path/to/database.json
 ```
 
 The underlying document creation logic lives in `arm_ex/documents.py`.
+
+`main_sql.py` can work with multiple language models. Choose a provider by
+setting the `LLM_PROVIDER` environment variable to `deepseek`, `gemini`, or
+`openai` (default `deepseek`). For each provider, supply the matching API key
+via `DEEPSEEK_API_KEY`, `GOOGLE_API_KEY`, or `OPENAI_API_KEY`. If the key is not
+found, the script will exit with an error.


### PR DESCRIPTION
## Summary
- load `DEEPSEEK_API_KEY` from the environment in `main_sql.py`
- fail fast if the key is missing
- document how to provide the DeepSeek API key

## Testing
- `python -m py_compile main_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_68759b1051c48322b1077a27493a30ce